### PR TITLE
Fix typo 'abilties'

### DIFF
--- a/Demos/D6-D7/Filters/AsyncEx/ShoutCastStream.pas
+++ b/Demos/D6-D7/Filters/AsyncEx/ShoutCastStream.pas
@@ -248,7 +248,7 @@ var
   MetaUrl: string;
   ErrMsg: string;
 begin
-  { -> This section includes the streamparser,fileripper and buffer abilties <-
+  { -> This section includes the streamparser,fileripper and buffer abilities <-
                todo: - code cleaning
                      - better helper functions or helper classes
   }


### PR DESCRIPTION
Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'abilities', you typed 'abilties'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

With kind regards,
TheTypoMaster
